### PR TITLE
Add logic so that secret key can be read from env

### DIFF
--- a/outgoing.go
+++ b/outgoing.go
@@ -156,12 +156,12 @@ func readVersionFile() {
 
 func main() {
 	flag.Parse()
+
 	if *secretKey == "" {
 		if os.Getenv("OUTGOING_SECRET_KEY") == "" {
-			log.Fatal("-key must be set.")
-		} else {
-			*secretKey = os.Getenv("OUTGOING_SECRET_KEY")
+			log.Fatal("-key or OUTGOING_SECRET_KEY (env varible) must be set.")
 		}
+		*secretKey = os.Getenv("OUTGOING_SECRET_KEY")
 	}
 
 	// load the version file once

--- a/outgoing.go
+++ b/outgoing.go
@@ -157,7 +157,11 @@ func readVersionFile() {
 func main() {
 	flag.Parse()
 	if *secretKey == "" {
-		log.Fatal("-key must be set.")
+		if os.Getenv("OUTGOING_SECRET_KEY") == "" {
+			log.Fatal("-key must be set.")
+		} else {
+			*secretKey = os.Getenv("OUTGOING_SECRET_KEY")
+		}
 	}
 
 	// load the version file once


### PR DESCRIPTION
@oremj r?

This is so that the secret key can be passed in via environment variable and don't show up on the command line.

Note that "-key" still overrides the environment variable.
